### PR TITLE
assert mismatched dimension

### DIFF
--- a/torch_sparse/spmm.py
+++ b/torch_sparse/spmm.py
@@ -15,6 +15,7 @@ def spmm(index, value, m, matrix):
 
     row, col = index
     matrix = matrix if matrix.dim() > 1 else matrix.unsqueeze(-1)
+    assert ((col.max() + 1) == matrix.size(0)), "Argument #3 (dense matrix): Expected dim 0 size {}, got {}".format((col.max() + 1), matrix.size(0))
 
     out = matrix[col]
     out = out * value.unsqueeze(-1)

--- a/torch_sparse/spmm.py
+++ b/torch_sparse/spmm.py
@@ -15,7 +15,8 @@ def spmm(index, value, m, matrix):
 
     row, col = index
     matrix = matrix if matrix.dim() > 1 else matrix.unsqueeze(-1)
-    assert ((col.max() + 1) == matrix.size(0)), "Argument #3 (dense matrix): Expected dim 0 size {}, got {}".format((col.max() + 1), matrix.size(0))
+    assert ((col.max() + 1) == matrix.size(0)), \
+    "Argument #3 (dense matrix): Expected dim 0 size {}, got {}".format((col.max() + 1), matrix.size(0))
 
     out = matrix[col]
     out = out * value.unsqueeze(-1)

--- a/torch_sparse/spmm.py
+++ b/torch_sparse/spmm.py
@@ -16,7 +16,8 @@ def spmm(index, value, m, matrix):
     row, col = index
     matrix = matrix if matrix.dim() > 1 else matrix.unsqueeze(-1)
     assert ((col.max() + 1) == matrix.size(0)), \
-    "Argument #3 (dense matrix): Expected dim 0 size {}, got {}".format((col.max() + 1), matrix.size(0))
+        "Argument #3 (dense matrix): Expected dim 0 size {}, got {}".\
+        format((col.max() + 1), matrix.size(0))
 
     out = matrix[col]
     out = out * value.unsqueeze(-1)


### PR DESCRIPTION
I got stuck one problem for a long period when using some graph convoluiton operators in PyG. The results were worse than what I had expected but everything works actually. I couldn't find the problem until I coincidentally noticed the dimension doesn't match. This could happen if one doesn't use collate_fn defined in your Batch. 

I guess **spmm** and maybe other torch_sparse operators requires the capacity to pose exceptions. Alternatively, would you consider replace torch_sparse with torch.sparse module