### PR TITLE
Add coalesce option to transpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Transposes dimensions 0 and 1 of a sparse matrix.
 * **value** *(Tensor)* - The value tensor of sparse matrix.
 * **m** *(int)* - The first dimension of corresponding dense matrix.
 * **n** *(int)* - The second dimension of corresponding dense matrix.
+* **coalesce** *(bool, optional)* - To return coalesced index and value or not (default: `True`)
 
 ### Returns
 

--- a/torch_sparse/transpose.py
+++ b/torch_sparse/transpose.py
@@ -2,7 +2,7 @@ import torch
 from torch_sparse import to_scipy, from_scipy, coalesce
 
 
-def transpose(index, value, m, n):
+def transpose(index, value, m, nm coalesce=True):
     """Transposes dimensions 0 and 1 of a sparse tensor.
 
     Args:
@@ -10,7 +10,7 @@ def transpose(index, value, m, n):
         value (:class:`Tensor`): The value tensor of sparse matrix.
         m (int): The first dimension of corresponding dense matrix.
         n (int): The second dimension of corresponding dense matrix.
-
+        coalesce (bool, optional): To return coalesced index and value or not (default: :obj:`True`) 
     :rtype: (:class:`LongTensor`, :class:`Tensor`)
     """
 
@@ -22,5 +22,6 @@ def transpose(index, value, m, n):
 
     row, col = index
     index = torch.stack([col, row], dim=0)
-    index, value = coalesce(index, value, n, m)
+    if coalesce:
+        index, value = coalesce(index, value, n, m)
     return index, value


### PR DESCRIPTION
Adds an optional arg `coalesce` to `transpose()`. Will speed up the operation if the output isn't required to be coalesced by the user.