### PR TITLE
Fix bug in `coalesced` arg of transpose

### DIFF
--- a/torch_sparse/transpose.py
+++ b/torch_sparse/transpose.py
@@ -23,6 +23,6 @@ def transpose(index, value, m, n, coalesced=True):
 
     row, col = index
     index = torch.stack([col, row], dim=0)
-    if coalesce:
+    if coalesced:
         index, value = coalesce(index, value, n, m)
     return index, value


### PR DESCRIPTION
Replaces `coalesce` with `coalesced`  in `if` condition as `coalesce` is a function and `coalesced` is an arg.