### PR TITLE
Check if CUDA is available before checking CUDA version

### DIFF
--- a/torch_sparse/__init__.py
+++ b/torch_sparse/__init__.py
@@ -12,7 +12,7 @@ for library in [
     torch.ops.load_library(importlib.machinery.PathFinder().find_spec(
         library, [osp.dirname(__file__)]).origin)
 
-if torch.version.cuda is not None:  # pragma: no cover
+if torch.version.cuda is not None and torch.cuda.is_available():  # pragma: no cover
     cuda_version = torch.ops.torch_sparse.cuda_version()
 
     if cuda_version == -1:


### PR DESCRIPTION
`torch.version.cuda` can still exists when it was installed CPU-only.

`torch_scatter` would need the same fix for it to work though. 

For now, the workaround is 
```python
import torch
if not torch.cuda.is_available():
    torch.version.cuda = None
```