### PR TITLE
Added autograd supported spspmm function and tests

### DIFF
--- a/torch_sparse/spspmm.py
+++ b/torch_sparse/spspmm.py
@@ -23,14 +23,7 @@ def spspmm(indexA, valueA, indexB, valueB, m, k, n, autograd=True, data_split=1,
     :rtype: (:class:`LongTensor`, :class:`Tensor`)
     """
     if autograd == True:
-        with torch.no_grad():
-            rowA, colA = indexA
-            rowB, colB = indexB
-            inc = int(k//data_split) + 1
-            indsA, indsB = pytorch_indexing.compare_all_elements(colA, rowB, k, data_split=data_split)
-            prod_inds = torch.cat((rowA[indsA].unsqueeze(0), colB[indsB].unsqueeze(0)), dim=0)
-        prod_vals = valueA[indsA]*valueB[indsB]
-        return coalesce(prod_inds, prod_vals, m, n)
+        return pytorch_indexing.spspmm(indexA, valueA, indexB, valueB, m, k, n, data_split=data_split)
     else:
         A = SparseTensor(row=indexA[0], col=indexA[1], value=valueA,
                      sparse_sizes=(m, k), is_sorted=not coalesced)


### PR DESCRIPTION
The autograd supported version is made default witn an optional argument in the spspmm file. It uses "compare_all_elements" from my package https://github.com/taylorpatti/pytorch_indexing.

The testing suite is temporarily put at the bottom of the spspmm.py file because I am getting a NoneType error on line 12/13 of the __init__.py file with respect to the file function whenever I run an import of the package within its directory (everything works outside though, so just a config problem). Any idea on the origin of that hiccup?