### PR TITLE
Fix several typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ For scattering, any operation of [`torch_scatter`](https://github.com/rusty1s/py
 
 * **index** *(LongTensor)* - The index tensor of sparse matrix.
 * **value** *(Tensor)* - The value tensor of sparse matrix.
-* **m** *(int)* - The first dimension of corresponding dense matrix.
-* **n** *(int)* - The second dimension of corresponding dense matrix.
+* **m** *(int)* - The first dimension of sparse matrix.
+* **n** *(int)* - The second dimension of sparse matrix.
 * **op** *(string, optional)* - The scatter operation to use. (default: `"add"`)
 
 #### Returns
@@ -158,8 +158,8 @@ Transposes dimensions 0 and 1 of a sparse matrix.
 
 * **index** *(LongTensor)* - The index tensor of sparse matrix.
 * **value** *(Tensor)* - The value tensor of sparse matrix.
-* **m** *(int)* - The first dimension of corresponding dense matrix.
-* **n** *(int)* - The second dimension of corresponding dense matrix.
+* **m** *(int)* - The first dimension of sparse matrix.
+* **n** *(int)* - The second dimension of sparse matrix.
 * **coalesced** *(bool, optional)* - If set to `False`, will not coalesce the output. (default: `True`)
 
 #### Returns
@@ -203,8 +203,8 @@ Matrix product of a sparse matrix with a dense matrix.
 
 * **index** *(LongTensor)* - The index tensor of sparse matrix.
 * **value** *(Tensor)* - The value tensor of sparse matrix.
-* **m** *(int)* - The first dimension of corresponding dense matrix.
-* **n** *(int)* - The second dimension of corresponding dense matrix.
+* **m** *(int)* - The first dimension of sparse matrix.
+* **n** *(int)* - The second dimension of sparse matrix.
 * **matrix** *(Tensor)* - The dense matrix.
 
 #### Returns
@@ -247,9 +247,9 @@ Both input sparse matrices need to be **coalesced** (use the `coalesced` attribu
 * **valueA** *(Tensor)* - The value tensor of first sparse matrix.
 * **indexB** *(LongTensor)* - The index tensor of second sparse matrix.
 * **valueB** *(Tensor)* - The value tensor of second sparse matrix.
-* **m** *(int)* - The first dimension of first corresponding dense matrix.
-* **k** *(int)* - The second dimension of first corresponding dense matrix and first dimension of second corresponding dense matrix.
-* **n** *(int)* - The second dimension of second corresponding dense matrix.
+* **m** *(int)* - The first dimension of first sparse matrix.
+* **k** *(int)* - The second dimension of first sparse matrix and first dimension of second sparse matrix.
+* **n** *(int)* - The second dimension of second sparse matrix.
 * **coalesced** *(bool, optional)*: If set to `True`, will coalesce both input sparse matrices. (default: `False`)
 
 #### Returns

--- a/torch_sparse/coalesce.py
+++ b/torch_sparse/coalesce.py
@@ -11,8 +11,8 @@ def coalesce(index, value, m, n, op="add"):
     Args:
         index (:class:`LongTensor`): The index tensor of sparse matrix.
         value (:class:`Tensor`): The value tensor of sparse matrix.
-        m (int): The first dimension of corresponding dense matrix.
-        n (int): The second dimension of corresponding dense matrix.
+        m (int): The first dimension of sparse matrix.
+        n (int): The second dimension of sparse matrix.
         op (string, optional): The scatter operation to use. (default:
             :obj:`"add"`)
 

--- a/torch_sparse/eye.py
+++ b/torch_sparse/eye.py
@@ -5,7 +5,7 @@ def eye(m, dtype=None, device=None):
     """Returns a sparse matrix with ones on the diagonal and zeros elsewhere.
 
     Args:
-        m (int): The first dimension of corresponding dense matrix.
+        m (int): The first dimension of sparse matrix.
         dtype (`torch.dtype`, optional): The desired data type of returned
             value vector. (default is set by `torch.set_default_tensor_type()`)
         device (`torch.device`, optional): The desired device of returned

--- a/torch_sparse/spmm.py
+++ b/torch_sparse/spmm.py
@@ -8,8 +8,8 @@ def spmm(index, value, m, n, matrix):
     Args:
         index (:class:`LongTensor`): The index tensor of sparse matrix.
         value (:class:`Tensor`): The value tensor of sparse matrix.
-        m (int): The first dimension of corresponding dense matrix.
-        n (int): The second dimension of corresponding dense matrix.
+        m (int): The first dimension of sparse matrix.
+        n (int): The second dimension of sparse matrix.
         matrix (:class:`Tensor`): The dense matrix.
 
     :rtype: :class:`Tensor`

--- a/torch_sparse/spspmm.py
+++ b/torch_sparse/spspmm.py
@@ -12,10 +12,10 @@ def spspmm(indexA, valueA, indexB, valueB, m, k, n, coalesced=False):
         valueA (:class:`Tensor`): The value tensor of first sparse matrix.
         indexB (:class:`LongTensor`): The index tensor of second sparse matrix.
         valueB (:class:`Tensor`): The value tensor of second sparse matrix.
-        m (int): The first dimension of first corresponding dense matrix.
-        k (int): The second dimension of first corresponding dense matrix and
-            first dimension of second corresponding dense matrix.
-        n (int): The second dimension of second corresponding dense matrix.
+        m (int): The first dimension of first sparse matrix.
+        k (int): The second dimension of first sparse matrix and first
+            dimension of second sparse matrix.
+        n (int): The second dimension of second sparse matrix.
         coalesced (bool, optional): If set to :obj:`True`, will coalesce both
             input sparse matrices. (default: :obj:`False`)
 

--- a/torch_sparse/transpose.py
+++ b/torch_sparse/transpose.py
@@ -42,8 +42,8 @@ def transpose(index, value, m, n, coalesced=True):
     Args:
         index (:class:`LongTensor`): The index tensor of sparse matrix.
         value (:class:`Tensor`): The value tensor of sparse matrix.
-        m (int): The first dimension of corresponding dense matrix.
-        n (int): The second dimension of corresponding dense matrix.
+        m (int): The first dimension of sparse matrix.
+        n (int): The second dimension of sparse matrix.
         coalesced (bool, optional): If set to :obj:`False`, will not coalesce
             the output. (default: :obj:`True`)
     :rtype: (:class:`LongTensor`, :class:`Tensor`)


### PR DESCRIPTION
Change the `corresponding dense matrix` to `sparse matrix` in the comments of several python files and readme.md