### PR TITLE
Skip unnecessary assertions and enable non-blocking data transfers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ BUILD_DOCS = os.getenv('BUILD_DOCS', '0') == '1'
 WITH_METIS = True if os.getenv('WITH_METIS', '0') == '1' else False
 WITH_MTMETIS = True if os.getenv('WITH_MTMETIS', '0') == '1' else False
 
+WITH_SYMBOLS = True if os.getenv('WITH_SYMBOLS', '0') == '1' else False
+
 
 def get_extensions():
     extensions = []
@@ -47,7 +49,7 @@ def get_extensions():
         extra_compile_args = {'cxx': ['-O2']}
         if not os.name == 'nt':  # Not on Windows:
             extra_compile_args['cxx'] += ['-Wno-sign-compare']
-        extra_link_args = ['-s']
+        extra_link_args = [] if WITH_SYMBOLS else ['-s']
 
         info = parallel_info()
         if ('backend: OpenMP' in info and 'OpenMP not found' not in info


### PR DESCRIPTION
# Summary

This backwards-compatible contribution enables higher performance by skipping assertions when they are unnecessary and allowing for truly non-blocking data transfers to the GPU.

# Problem

When profiling the performance of a torch-geometric code using nvprof, I found out that setting `non_blocking=True` when doing data transfers still blocks the current CUDA stream. The underlying reason is that when the `to` method is called to initiate a data transfer, we construct a new `SparseStorage` object which repeats some assertions that have already been evaluated on this data. The particular assertions run when the `row` or `col` tensors are present, checking that their content conforms with `sparse_sizes`. The problem with such assertions is that they require a blocking round-trip of communication between the CPU and GPU, which defeats the purpose of `non_blocking=True`.

# Solution

The solution to the assertion problem is to use a `trust_data` construction argument as an invariant that tells us whether we need to run these assertions. Data transfers or dtype changes do not need these assertions, because the matrix structure was already checked upon construction. Certain other operations such as `eye` do not need them either, because they are correct by construction.

In addition, I refactored the dtype and data transfer API to align with `torch.Tensor` and avoid the construction of dummy tensor objects, removing wasted time in the PyTorch allocator.

# Code changes

* Uses the `trust_data` invariant to skip blocking assertions, when unnecessary, during construction of `SparseStorage` objects.
* Refactors the dtype and device transfer APIs to align with `torch.Tensor` while maintaining backward compatibility.
* No longer constructs dummy tensors when changing dtype or device.
* Adds `WITH_SYMBOLS` option  to allow for linking without stripping symbols in `setup.py`