### PR TITLE
Add options to conditionally include Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(TORCHSPARSE_VERSION 0.6.12)
 
 option(WITH_CUDA "Enable CUDA support" OFF)
+option(WITH_PYTHON "Link to Python when building" ON)
 
 if(WITH_CUDA)
   enable_language(CUDA)
@@ -12,7 +13,10 @@ if(WITH_CUDA)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 endif()
 
-find_package(Python3 COMPONENTS Development)
+if (WITH_PYTHON)
+  add_definitions(-DWITH_PYTHON)
+  find_package(Python3 COMPONENTS Development)
+endif()
 find_package(Torch REQUIRED)
 
 file(GLOB HEADERS csrc/sparse.h)
@@ -22,7 +26,10 @@ if(WITH_CUDA)
 endif()
 
 add_library(${PROJECT_NAME} SHARED ${OPERATOR_SOURCES})
-target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES} Python3::Python)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES})
+if (WITH_PYTHON)
+  target_link_libraries(${PROJECT_NAME} PRIVATE Python3::Python)
+endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME TorchSparse)
 
 target_include_directories(${PROJECT_NAME} INTERFACE

--- a/csrc/convert.cpp
+++ b/csrc/convert.cpp
@@ -10,10 +10,12 @@
 #endif
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__convert_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__convert_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/convert.cpp
+++ b/csrc/convert.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/convert_cpu.h"

--- a/csrc/cpu/convert_cpu.h
+++ b/csrc/cpu/convert_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 torch::Tensor ind2ptr_cpu(torch::Tensor ind, int64_t M);
 torch::Tensor ptr2ind_cpu(torch::Tensor ptr, int64_t E);

--- a/csrc/cpu/convert_cpu.h
+++ b/csrc/cpu/convert_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 torch::Tensor ind2ptr_cpu(torch::Tensor ind, int64_t M);
 torch::Tensor ptr2ind_cpu(torch::Tensor ptr, int64_t E);

--- a/csrc/cpu/diag_cpu.h
+++ b/csrc/cpu/diag_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 torch::Tensor non_diag_mask_cpu(torch::Tensor row, torch::Tensor col, int64_t M,
                                 int64_t N, int64_t k);

--- a/csrc/cpu/diag_cpu.h
+++ b/csrc/cpu/diag_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 torch::Tensor non_diag_mask_cpu(torch::Tensor row, torch::Tensor col, int64_t M,
                                 int64_t N, int64_t k);

--- a/csrc/cpu/ego_sample_cpu.h
+++ b/csrc/cpu/ego_sample_cpu.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
-#include <unistd.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor,
            torch::Tensor, torch::Tensor>

--- a/csrc/cpu/ego_sample_cpu.h
+++ b/csrc/cpu/ego_sample_cpu.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
+#include <unistd.h>
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor,
            torch::Tensor, torch::Tensor>

--- a/csrc/cpu/hgt_sample_cpu.h
+++ b/csrc/cpu/hgt_sample_cpu.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
-#include <unistd.h>
+#include "../extensions.h"
 
 typedef std::string node_t;
 typedef std::string rel_t;

--- a/csrc/cpu/hgt_sample_cpu.h
+++ b/csrc/cpu/hgt_sample_cpu.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
+#include <unistd.h>
 
 typedef std::string node_t;
 typedef std::string rel_t;

--- a/csrc/cpu/metis_cpu.h
+++ b/csrc/cpu/metis_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 torch::Tensor partition_cpu(torch::Tensor rowptr, torch::Tensor col,
                             torch::optional<torch::Tensor> optional_value,

--- a/csrc/cpu/metis_cpu.h
+++ b/csrc/cpu/metis_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 torch::Tensor partition_cpu(torch::Tensor rowptr, torch::Tensor col,
                             torch::optional<torch::Tensor> optional_value,

--- a/csrc/cpu/neighbor_sample_cpu.h
+++ b/csrc/cpu/neighbor_sample_cpu.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
+#include <unistd.h>
 
 typedef std::string node_t;
 typedef std::tuple<std::string, std::string, std::string> edge_t;

--- a/csrc/cpu/neighbor_sample_cpu.h
+++ b/csrc/cpu/neighbor_sample_cpu.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
-#include <unistd.h>
+#include "../extensions.h"
 
 typedef std::string node_t;
 typedef std::tuple<std::string, std::string, std::string> edge_t;

--- a/csrc/cpu/relabel_cpu.h
+++ b/csrc/cpu/relabel_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 std::tuple<torch::Tensor, torch::Tensor> relabel_cpu(torch::Tensor col,
                                                      torch::Tensor idx);

--- a/csrc/cpu/relabel_cpu.h
+++ b/csrc/cpu/relabel_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::Tensor> relabel_cpu(torch::Tensor col,
                                                      torch::Tensor idx);

--- a/csrc/cpu/rw_cpu.h
+++ b/csrc/cpu/rw_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 torch::Tensor random_walk_cpu(torch::Tensor rowptr, torch::Tensor col,
                               torch::Tensor start, int64_t walk_length);

--- a/csrc/cpu/rw_cpu.h
+++ b/csrc/cpu/rw_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 torch::Tensor random_walk_cpu(torch::Tensor rowptr, torch::Tensor col,
                               torch::Tensor start, int64_t walk_length);

--- a/csrc/cpu/saint_cpu.h
+++ b/csrc/cpu/saint_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 subgraph_cpu(torch::Tensor idx, torch::Tensor rowptr, torch::Tensor row,

--- a/csrc/cpu/saint_cpu.h
+++ b/csrc/cpu/saint_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 subgraph_cpu(torch::Tensor idx, torch::Tensor rowptr, torch::Tensor row,

--- a/csrc/cpu/sample_cpu.h
+++ b/csrc/cpu/sample_cpu.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
+#include <unistd.h>
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 sample_adj_cpu(torch::Tensor rowptr, torch::Tensor col, torch::Tensor idx,

--- a/csrc/cpu/sample_cpu.h
+++ b/csrc/cpu/sample_cpu.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
-#include <unistd.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 sample_adj_cpu(torch::Tensor rowptr, torch::Tensor col, torch::Tensor idx,

--- a/csrc/cpu/spmm_cpu.h
+++ b/csrc/cpu/spmm_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
 spmm_cpu(torch::Tensor rowptr, torch::Tensor col,

--- a/csrc/cpu/spmm_cpu.h
+++ b/csrc/cpu/spmm_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
 spmm_cpu(torch::Tensor rowptr, torch::Tensor col,

--- a/csrc/cpu/spspmm_cpu.h
+++ b/csrc/cpu/spspmm_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 std::tuple<torch::Tensor, torch::Tensor, torch::optional<torch::Tensor>>
 spspmm_cpu(torch::Tensor rowptrA, torch::Tensor colA,

--- a/csrc/cpu/spspmm_cpu.h
+++ b/csrc/cpu/spspmm_cpu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::Tensor, torch::optional<torch::Tensor>>
 spspmm_cpu(torch::Tensor rowptrA, torch::Tensor colA,

--- a/csrc/cpu/utils.h
+++ b/csrc/cpu/utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 #define CHECK_CPU(x) AT_ASSERTM(x.device().is_cpu(), #x " must be CPU tensor")
 #define CHECK_INPUT(x) AT_ASSERTM(x, "Input mismatch")

--- a/csrc/cpu/utils.h
+++ b/csrc/cpu/utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 #define CHECK_CPU(x) AT_ASSERTM(x.device().is_cpu(), #x " must be CPU tensor")
 #define CHECK_INPUT(x) AT_ASSERTM(x, "Input mismatch")

--- a/csrc/cuda/convert_cuda.h
+++ b/csrc/cuda/convert_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 torch::Tensor ind2ptr_cuda(torch::Tensor ind, int64_t M);
 torch::Tensor ptr2ind_cuda(torch::Tensor ptr, int64_t E);

--- a/csrc/cuda/convert_cuda.h
+++ b/csrc/cuda/convert_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 torch::Tensor ind2ptr_cuda(torch::Tensor ind, int64_t M);
 torch::Tensor ptr2ind_cuda(torch::Tensor ptr, int64_t E);

--- a/csrc/cuda/diag_cuda.h
+++ b/csrc/cuda/diag_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 torch::Tensor non_diag_mask_cuda(torch::Tensor row, torch::Tensor col,
                                  int64_t M, int64_t N, int64_t k);

--- a/csrc/cuda/diag_cuda.h
+++ b/csrc/cuda/diag_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 torch::Tensor non_diag_mask_cuda(torch::Tensor row, torch::Tensor col,
                                  int64_t M, int64_t N, int64_t k);

--- a/csrc/cuda/rw_cuda.h
+++ b/csrc/cuda/rw_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 torch::Tensor random_walk_cuda(torch::Tensor rowptr, torch::Tensor col,
                                torch::Tensor start, int64_t walk_length);

--- a/csrc/cuda/rw_cuda.h
+++ b/csrc/cuda/rw_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 torch::Tensor random_walk_cuda(torch::Tensor rowptr, torch::Tensor col,
                                torch::Tensor start, int64_t walk_length);

--- a/csrc/cuda/spmm_cuda.h
+++ b/csrc/cuda/spmm_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
 spmm_cuda(torch::Tensor rowptr, torch::Tensor col,

--- a/csrc/cuda/spmm_cuda.h
+++ b/csrc/cuda/spmm_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::optional<torch::Tensor>>
 spmm_cuda(torch::Tensor rowptr, torch::Tensor col,

--- a/csrc/cuda/spspmm_cuda.h
+++ b/csrc/cuda/spspmm_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 std::tuple<torch::Tensor, torch::Tensor, torch::optional<torch::Tensor>>
 spspmm_cuda(torch::Tensor rowptrA, torch::Tensor colA,

--- a/csrc/cuda/spspmm_cuda.h
+++ b/csrc/cuda/spspmm_cuda.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 std::tuple<torch::Tensor, torch::Tensor, torch::optional<torch::Tensor>>
 spspmm_cuda(torch::Tensor rowptrA, torch::Tensor colA,

--- a/csrc/cuda/utils.cuh
+++ b/csrc/cuda/utils.cuh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 #define CHECK_CUDA(x)                                                          \
   AT_ASSERTM(x.device().is_cuda(), #x " must be CUDA tensor")

--- a/csrc/cuda/utils.cuh
+++ b/csrc/cuda/utils.cuh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/torch.h>
+#include "../extensions.h"
 
 #define CHECK_CUDA(x)                                                          \
   AT_ASSERTM(x.device().is_cuda(), #x " must be CUDA tensor")

--- a/csrc/diag.cpp
+++ b/csrc/diag.cpp
@@ -10,10 +10,12 @@
 #endif
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__diag_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__diag_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/diag.cpp
+++ b/csrc/diag.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/diag_cpu.h"

--- a/csrc/ego_sample.cpp
+++ b/csrc/ego_sample.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/ego_sample_cpu.h"

--- a/csrc/ego_sample.cpp
+++ b/csrc/ego_sample.cpp
@@ -6,10 +6,12 @@
 #include "cpu/ego_sample_cpu.h"
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__ego_sample_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__ego_sample_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/extensions.h
+++ b/csrc/extensions.h
@@ -1,0 +1,9 @@
+
+#include <torch/torch.h>
+
+// for getpid()
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif

--- a/csrc/hgt_sample.cpp
+++ b/csrc/hgt_sample.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/hgt_sample_cpu.h"

--- a/csrc/hgt_sample.cpp
+++ b/csrc/hgt_sample.cpp
@@ -6,10 +6,12 @@
 #include "cpu/hgt_sample_cpu.h"
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__hgt_sample_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__hgt_sample_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/metis.cpp
+++ b/csrc/metis.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/metis_cpu.h"

--- a/csrc/metis.cpp
+++ b/csrc/metis.cpp
@@ -6,10 +6,12 @@
 #include "cpu/metis_cpu.h"
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__metis_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__metis_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/neighbor_sample.cpp
+++ b/csrc/neighbor_sample.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/neighbor_sample_cpu.h"

--- a/csrc/neighbor_sample.cpp
+++ b/csrc/neighbor_sample.cpp
@@ -6,10 +6,12 @@
 #include "cpu/neighbor_sample_cpu.h"
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__neighbor_sample_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__neighbor_sample_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/relabel.cpp
+++ b/csrc/relabel.cpp
@@ -6,10 +6,12 @@
 #include "cpu/relabel_cpu.h"
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__relabel_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__relabel_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/relabel.cpp
+++ b/csrc/relabel.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/relabel_cpu.h"

--- a/csrc/rw.cpp
+++ b/csrc/rw.cpp
@@ -10,10 +10,12 @@
 #endif
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__rw_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__rw_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/rw.cpp
+++ b/csrc/rw.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/rw_cpu.h"

--- a/csrc/saint.cpp
+++ b/csrc/saint.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/saint_cpu.h"

--- a/csrc/saint.cpp
+++ b/csrc/saint.cpp
@@ -6,10 +6,12 @@
 #include "cpu/saint_cpu.h"
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__saint_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__saint_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/sample.cpp
+++ b/csrc/sample.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/sample_cpu.h"

--- a/csrc/sample.cpp
+++ b/csrc/sample.cpp
@@ -6,10 +6,12 @@
 #include "cpu/sample_cpu.h"
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__sample_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__sample_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/sparse.h
+++ b/csrc/sparse.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/library.h>
 
 int64_t cuda_version();
 

--- a/csrc/spmm.cpp
+++ b/csrc/spmm.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/spmm_cpu.h"

--- a/csrc/spmm.cpp
+++ b/csrc/spmm.cpp
@@ -10,10 +10,12 @@
 #endif
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__spmm_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__spmm_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/spspmm.cpp
+++ b/csrc/spspmm.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #include "cpu/spspmm_cpu.h"

--- a/csrc/spspmm.cpp
+++ b/csrc/spspmm.cpp
@@ -10,10 +10,12 @@
 #endif
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__spspmm_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__spspmm_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/version.cpp
+++ b/csrc/version.cpp
@@ -8,10 +8,12 @@
 #endif
 
 #ifdef _WIN32
+#ifdef WITH_PYTHON
 #ifdef WITH_CUDA
 PyMODINIT_FUNC PyInit__version_cuda(void) { return NULL; }
 #else
 PyMODINIT_FUNC PyInit__version_cpu(void) { return NULL; }
+#endif
 #endif
 #endif
 

--- a/csrc/version.cpp
+++ b/csrc/version.cpp
@@ -1,4 +1,6 @@
+#ifdef WITH_PYTHON
 #include <Python.h>
+#endif
 #include <torch/script.h>
 
 #ifdef WITH_CUDA

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def get_extensions():
     main_files = glob.glob(osp.join(extensions_dir, '*.cpp'))
 
     for main, suffix in product(main_files, suffices):
-        define_macros = []
+        define_macros = [('WITH_PYTHON', None)]
         libraries = []
         if WITH_METIS:
             define_macros += [('WITH_METIS', None)]


### PR DESCRIPTION
Hi everyone! 

Thanks for this amazing package!

I'm working on a port of pytorch_sparse for the [R language](https://www.r-project.org/) so users can benefit of the sparse operators  together with [torch](https://github.com/mlverse/torch). The current version lives in this [repo](https://github.com/mlverse/torchsparse).
It would be nice though if one could use the C++ library without linking to Python.

This PR adds a CMake option `WITH_PYTHON` that when set to `OFF` allows the package to be built entirely without linking to Python. By default, we tried to keep the same behavior, link to Python and include `Python.h` headers.
