### PR TITLE
used explicit at::Half to __half conversion operator to fix ambiguous…

### DIFF
--- a/csrc/cuda/utils.cuh
+++ b/csrc/cuda/utils.cuh
@@ -8,11 +8,11 @@
 
 __device__ __inline__ at::Half
 __shfl_sync(const unsigned mask, const at::Half var, const int srcLane) {
-  return __shfl_sync(mask, (__half)var, srcLane);
+  return __shfl_sync(mask, var.operator __half(), srcLane);
 }
 
 __device__ __inline__ at::Half __shfl_down_sync(const unsigned mask,
                                                 const at::Half var,
                                                 const unsigned int delta) {
-  return __shfl_down_sync(mask, (__half)var, delta);
+  return __shfl_down_sync(mask, var.operator __half(), delta);
 }


### PR DESCRIPTION
Made the conversion from at::Half to __half explicit in order to solve the 'ambiguous conversion' problem, when building C++ API