### PR TITLE
Fixing `WITH_PYTHON` CMake option support

### DIFF
--- a/csrc/extensions.h
+++ b/csrc/extensions.h
@@ -1,2 +1,2 @@
 #include "macros.h"
-#include <torch/extension.h>
+#include <torch/torch.h>

--- a/csrc/sparse.h
+++ b/csrc/sparse.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <torch/extension.h>
-
+#include "extensions.h"
 #include "macros.h"
 
 namespace sparse {


### PR DESCRIPTION
As discussed in #259.

Again allows the compilation of the library without linking to python as introduced by PR #196 