### PR TITLE
Fix `HGTLoader` bug producing output dictionaries missing edge types

### DIFF
--- a/csrc/cpu/hgt_sample_cpu.cpp
+++ b/csrc/cpu/hgt_sample_cpu.cpp
@@ -224,12 +224,10 @@ hgt_sample_cpu(const c10::Dict<rel_t, torch::Tensor> &colptr_dict,
         }
       }
     }
-    if (rows.size() > 0) {
-      out_row_dict.insert(rel_type, from_vector<int64_t>(rows));
-      out_col_dict.insert(rel_type, from_vector<int64_t>(cols));
-      out_edge_dict.insert(rel_type, from_vector<int64_t>(edges));
-    }
-  }
+    out_row_dict.insert(rel_type, from_vector<int64_t>(rows));
+    out_col_dict.insert(rel_type, from_vector<int64_t>(cols));
+    out_edge_dict.insert(rel_type, from_vector<int64_t>(edges));
+}
 
   // Generate tensor-valued output node dictionary (line 20):
   for (const auto &kv : nodes_dict) {


### PR DESCRIPTION
This PR fixes the `HGTLoader` bug mentioned in [this discussion](https://torchgeometricco.slack.com/archives/C01DN0B3B1N/p1658148483547519), whereby certain edge types were not included in the sampled output. PyG tests in https://github.com/pyg-team/pytorch_geometric/pull/5067 will pass with this fix.