### PR TITLE
Add `spmm` bf16 support

### DIFF
--- a/csrc/cpu/spmm_cpu.cpp
+++ b/csrc/cpu/spmm_cpu.cpp
@@ -44,7 +44,7 @@ spmm_cpu(torch::Tensor rowptr, torch::Tensor col,
   auto K = mat.size(-1);
   auto B = mat.numel() / (N * K);
 
-  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, mat.scalar_type(), "_", [&] {
+  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, mat.scalar_type(), "spmm_cpu", [&] {
     scalar_t *value_data = nullptr;
     auto mat_data = mat.data_ptr<scalar_t>();
     auto out_data = out.data_ptr<scalar_t>();
@@ -123,7 +123,7 @@ torch::Tensor spmm_value_bw_cpu(torch::Tensor row, torch::Tensor rowptr,
   auto row_data = row.data_ptr<int64_t>();
   auto rowptr_data = rowptr.data_ptr<int64_t>();
   auto col_data = col.data_ptr<int64_t>();
-  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, mat.scalar_type(), "_", [&] {
+  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, mat.scalar_type(), "spmm_value_bw_cpu", [&] {
     auto mat_data = mat.data_ptr<scalar_t>();
     auto grad_data = grad.data_ptr<scalar_t>();
     auto out_data = out.data_ptr<scalar_t>();

--- a/csrc/cpu/spspmm_cpu.cpp
+++ b/csrc/cpu/spspmm_cpu.cpp
@@ -55,7 +55,7 @@ spspmm_cpu(torch::Tensor rowptrA, torch::Tensor colA,
   torch::Tensor colC;
   torch::optional<torch::Tensor> optional_valueC = torch::nullopt;
 
-  AT_DISPATCH_ALL_TYPES(scalar_type, "spspmm", [&] {
+  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::BFloat16, scalar_type, "spspmm", [&] {
     AT_DISPATCH_HAS_VALUE(optional_valueA, [&] {
       scalar_t *valA_data = nullptr, *valB_data = nullptr;
       if (HAS_VALUE) {
@@ -77,7 +77,7 @@ spspmm_cpu(torch::Tensor rowptrA, torch::Tensor colA,
             if (HAS_VALUE)
               tmp_vals[cB] += valA_data[eA] * valB_data[eB];
             else
-              tmp_vals[cB]++;
+              tmp_vals[cB] += 1;
           }
         }
 

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -66,28 +66,3 @@ def test_spspmm(dtype, device):
     assert rowptr.tolist() == [0, 1, 2, 3]
     assert col.tolist() == [0, 1, 2]
 
-
-grad_dtypes.append(torch.bfloat16)
-
-
-@pytest.mark.parametrize('dtype,device,reduce',
-                         product(grad_dtypes, devices, reductions))
-def test_spmm_forward(dtype, device, reduce):
-    src = torch.randn((10, 8), dtype=dtype, device=device)
-    src[2:4, :] = 0  # Remove multiple rows.
-    src[:, 2:4] = 0  # Remove multiple columns.
-    src = SparseTensor.from_dense(src)
-    row, col, value = src.coo()
-
-    other = torch.randn((2, 8, 2), dtype=dtype, device=device)
-
-    src_col = other.index_select(-2, col) * value.unsqueeze(-1)
-    expected = torch_scatter.scatter(src_col, row, dim=-2, reduce=reduce)
-    if reduce == 'min':
-        expected[expected > 1000] = 0
-    if reduce == 'max':
-        expected[expected < -1000] = 0
-
-    out = matmul(src, other, reduce)
-
-    assert torch.allclose(expected, out, atol=1e-2)

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -65,3 +65,29 @@ def test_spspmm(dtype, device):
     rowptr, col, value = out.csr()
     assert rowptr.tolist() == [0, 1, 2, 3]
     assert col.tolist() == [0, 1, 2]
+
+
+grad_dtypes.append(torch.bfloat16)
+
+
+@pytest.mark.parametrize('dtype,device,reduce',
+                         product(grad_dtypes, devices, reductions))
+def test_spmm_forward(dtype, device, reduce):
+    src = torch.randn((10, 8), dtype=dtype, device=device)
+    src[2:4, :] = 0  # Remove multiple rows.
+    src[:, 2:4] = 0  # Remove multiple columns.
+    src = SparseTensor.from_dense(src)
+    row, col, value = src.coo()
+
+    other = torch.randn((2, 8, 2), dtype=dtype, device=device)
+
+    src_col = other.index_select(-2, col) * value.unsqueeze(-1)
+    expected = torch_scatter.scatter(src_col, row, dim=-2, reduce=reduce)
+    if reduce == 'min':
+        expected[expected > 1000] = 0
+    if reduce == 'max':
+        expected[expected < -1000] = 0
+
+    out = matmul(src, other, reduce)
+
+    assert torch.allclose(expected, out, atol=1e-2)

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -65,4 +65,3 @@ def test_spspmm(dtype, device):
     rowptr, col, value = out.csr()
     assert rowptr.tolist() == [0, 1, 2, 3]
     assert col.tolist() == [0, 1, 2]
-

--- a/test/test_spspmm.py
+++ b/test/test_spspmm.py
@@ -6,6 +6,8 @@ from torch_sparse import spspmm, SparseTensor
 
 from .utils import grad_dtypes, devices, tensor
 
+grad_dtypes.append(torch.bfloat16)
+
 
 @pytest.mark.parametrize('dtype,device', product(grad_dtypes, devices))
 def test_spspmm(dtype, device):
@@ -35,7 +37,7 @@ def test_sparse_tensor_spspmm(dtype, device):
         ], dtype=dtype, device=device),
     )
 
-    expected = torch.eye(10, dtype=dtype, device=device)
+    expected = torch.eye(10, device=device).to(dtype)
 
     out = x @ x.to_dense().t()
     assert torch.allclose(out, expected, atol=1e-2)

--- a/test/test_spspmm.py
+++ b/test/test_spspmm.py
@@ -6,8 +6,6 @@ from torch_sparse import spspmm, SparseTensor
 
 from .utils import grad_dtypes, devices, tensor
 
-grad_dtypes.append(torch.bfloat16)
-
 
 @pytest.mark.parametrize('dtype,device', product(grad_dtypes, devices))
 def test_spspmm(dtype, device):

--- a/test/utils.py
+++ b/test/utils.py
@@ -10,7 +10,6 @@ grad_dtypes = [torch.half, torch.float, torch.double]
 if version.parse(torch_scatter.__version__) > version.parse("2.0.9"):
     dtypes.append(torch.bfloat16)
     grad_dtypes.append(torch.bfloat16)
-del torch_scatter
 
 devices = [torch.device('cpu')]
 if torch.cuda.is_available():

--- a/test/utils.py
+++ b/test/utils.py
@@ -2,9 +2,14 @@ import torch
 
 reductions = ['sum', 'add', 'mean', 'min', 'max']
 
-dtypes = [torch.half, torch.bfloat16, torch.float, torch.double,
-          torch.int, torch.long]
+dtypes = [torch.half, torch.float, torch.double, torch.int, torch.long]
 grad_dtypes = [torch.half, torch.float, torch.double]
+
+import torch_scatter
+if torch_scatter.__version__ > '2.0.9':
+    dtypes.append(torch.bfloat16)
+    grad_dtypes.append(torch.bfloat16)
+del torch_scatter
 
 devices = [torch.device('cpu')]
 if torch.cuda.is_available():

--- a/test/utils.py
+++ b/test/utils.py
@@ -2,7 +2,8 @@ import torch
 
 reductions = ['sum', 'add', 'mean', 'min', 'max']
 
-dtypes = [torch.half, torch.float, torch.double, torch.int, torch.long]
+dtypes = [torch.half, torch.bfloat16, torch.float, torch.double,
+          torch.int, torch.long]
 grad_dtypes = [torch.half, torch.float, torch.double]
 
 devices = [torch.device('cpu')]

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,12 +1,13 @@
 import torch
+import torch_scatter
+from packaging import version
 
 reductions = ['sum', 'add', 'mean', 'min', 'max']
 
 dtypes = [torch.half, torch.float, torch.double, torch.int, torch.long]
 grad_dtypes = [torch.half, torch.float, torch.double]
 
-import torch_scatter
-if torch_scatter.__version__ > '2.0.9':
+if version.parse(torch_scatter.__version__) > version.parse("2.0.9"):
     dtypes.append(torch.bfloat16)
     grad_dtypes.append(torch.bfloat16)
 del torch_scatter


### PR DESCRIPTION
This PR is to add BF16 support for spmm kernel implementation in torch_sparse. And the dispatch name is needed to keep unique.
BF16 UT has been added in test_matmul.py, `matmul` can run into spmm kernel.