### PR TITLE
Add pyproject.toml with PEP 517 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "torch", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This adds a `pyproject.toml` with a `build-system.requires` section that includes `torch`, which triggers `torch` to be installed before building `torch_sparse`. One caveat might be what you mention in https://github.com/rusty1s/pytorch_sparse/issues/157#issuecomment-893458025 that the specific version of `torch` (both direct version + CUDA version) would be unspecified, but my understanding is it would basically pick the latest version available (I think this might still be more desirable than the current errors?). The default `torch` wheels when building on linux are compiled with CUDA support (I think the default 1.13 wheels uses CUDA 11.7).

If acceptable, this should fix #156.
