### PR TITLE
Fix compilation errors occurring when building with PyTorch-nightly

### DIFF
--- a/csrc/version.cpp
+++ b/csrc/version.cpp
@@ -38,4 +38,4 @@ SPARSE_API int64_t cuda_version() noexcept {
 } // namespace sparse
 
 static auto registry = torch::RegisterOperators().op(
-    "torch_sparse::cuda_version", &sparse::cuda_version);
+    "torch_sparse::cuda_version", [] { return sparse::cuda_version(); });


### PR DESCRIPTION
Fix compilation errors occurring when building with PyTorch-nightly.
Wrapping the `cuda_version` function with a lambda helps to deduce template type.

Related PR: [pytorch_scatter::PR-347](https://github.com/rusty1s/pytorch_scatter/pull/347)