### PR TITLE
Enable `index_sort`

### DIFF
--- a/torch_sparse/storage.py
+++ b/torch_sparse/storage.py
@@ -3,7 +3,7 @@ from typing import Optional, List, Tuple
 
 import torch
 from torch_scatter import segment_csr, scatter_add
-from torch_sparse.utils import Final
+from torch_sparse.utils import Final, index_sort
 
 layouts: Final[List[str]] = ['coo', 'csr', 'csc']
 
@@ -151,7 +151,7 @@ class SparseStorage(object):
             idx[1:] *= self._sparse_sizes[1]
             idx[1:] += self._col
             if (idx[1:] < idx[:-1]).any():
-                perm = idx[1:].argsort()
+                _, perm = index_sort(idx[1:])
                 self._row = self.row()[perm]
                 self._col = self._col[perm]
                 if value is not None:
@@ -389,7 +389,7 @@ class SparseStorage(object):
             return csr2csc
 
         idx = self._sparse_sizes[0] * self._col + self.row()
-        csr2csc = idx.argsort()
+        _, csr2csc = index_sort(idx)
         self._csr2csc = csr2csc
         return csr2csc
 
@@ -401,7 +401,7 @@ class SparseStorage(object):
         if csc2csr is not None:
             return csc2csr
 
-        csc2csr = self.csr2csc().argsort()
+        _, csc2csr = index_sort(self.csr2csc())
         self._csc2csr = csc2csr
         return csc2csr
 

--- a/torch_sparse/typing.py
+++ b/torch_sparse/typing.py
@@ -1,0 +1,8 @@
+try:
+    import pyg_lib  # noqa
+    WITH_PYG_LIB = True
+    WITH_INDEX_SORT = hasattr(pyg_lib.ops, 'index_sort')
+except ImportError:
+    pyg_lib = object
+    WITH_PYG_LIB = False
+    WITH_INDEX_SORT = False

--- a/torch_sparse/utils.py
+++ b/torch_sparse/utils.py
@@ -1,10 +1,43 @@
-from typing import Any
+import torch
+from typing import Any, Optional, Tuple
+
+try:
+    import pyg_lib  # noqa
+    WITH_PYG_LIB = True
+except ImportError:
+    pyg_lib = object
+    WITH_PYG_LIB = False
 
 try:
     from typing_extensions import Final  # noqa
 except ImportError:
     from torch.jit import Final  # noqa
 
+if WITH_PYG_LIB:  # pragma: no cover
+
+    def index_sort(
+            inputs: torch.Tensor,
+            max_value: Optional[int] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """This function should be used only for positive integer values. See
+        pyg-lib docuemntation for more details:
+        https://pyg-lib.readthedocs.io/en/latest/modules/ops.html"""
+        if inputs.dim() == 1 and is_integral(inputs):
+            return pyg_lib.ops.index_sort(inputs, max_value=max_value)
+        return inputs.sort()
+
+else:
+
+    def index_sort(
+            inputs: torch.Tensor,
+            max_value: Optional[int] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return inputs.sort()
+
 
 def is_scalar(other: Any) -> bool:
     return isinstance(other, int) or isinstance(other, float)
+
+
+def is_integral(tensor: torch.Tensor) -> bool:
+    return tensor.dtype in [torch.int8, torch.int16, torch.int32, torch.int64]

--- a/torch_sparse/utils.py
+++ b/torch_sparse/utils.py
@@ -1,43 +1,26 @@
-import torch
 from typing import Any, Optional, Tuple
 
-try:
-    import pyg_lib  # noqa
-    WITH_PYG_LIB = True
-except ImportError:
-    pyg_lib = object
-    WITH_PYG_LIB = False
+import torch
+
+import torch_sparse.typing
+from torch_sparse.typing import pyg_lib
 
 try:
     from typing_extensions import Final  # noqa
 except ImportError:
     from torch.jit import Final  # noqa
 
-if WITH_PYG_LIB:  # pragma: no cover
 
-    def index_sort(
-            inputs: torch.Tensor,
-            max_value: Optional[int] = None
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """This function should be used only for positive integer values. See
-        pyg-lib docuemntation for more details:
-        https://pyg-lib.readthedocs.io/en/latest/modules/ops.html"""
-        if inputs.dim() == 1 and is_integral(inputs):
-            return pyg_lib.ops.index_sort(inputs, max_value=max_value)
+@torch.jit.script
+def index_sort(
+        inputs: torch.Tensor,
+        max_value: Optional[int] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""See pyg-lib documentation for more details:
+    https://pyg-lib.readthedocs.io/en/latest/modules/ops.html"""
+    if not torch_sparse.typing.WITH_INDEX_SORT:  # pragma: no cover
         return inputs.sort()
-
-else:
-
-    def index_sort(
-            inputs: torch.Tensor,
-            max_value: Optional[int] = None
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        return inputs.sort()
+    return pyg_lib.ops.index_sort(inputs, max_value)
 
 
 def is_scalar(other: Any) -> bool:
     return isinstance(other, int) or isinstance(other, float)
-
-
-def is_integral(tensor: torch.Tensor) -> bool:
-    return tensor.dtype in [torch.int8, torch.int16, torch.int32, torch.int64]

--- a/torch_sparse/utils.py
+++ b/torch_sparse/utils.py
@@ -11,7 +11,6 @@ except ImportError:
     from torch.jit import Final  # noqa
 
 
-@torch.jit.script
 def index_sort(
         inputs: torch.Tensor,
         max_value: Optional[int] = None) -> Tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
Enable `index_sort` introduced in [pyg-lib](https://pyg-lib.readthedocs.io/en/latest/modules/ops.html#pyg_lib.ops.index_sort).

Related PR: [pytorch_geometric:6554](https://github.com/pyg-team/pytorch_geometric/pull/6554)