### PR TITLE
Add docs to `torch_sparse.matmul`

### DIFF
--- a/torch_sparse/matmul.py
+++ b/torch_sparse/matmul.py
@@ -147,8 +147,7 @@ def matmul(src, other, reduce="sum"):  # noqa: F811
      method allows us to use other aggregation functions as well.
 
     Args:
-        src (:class:`Tensor`): A sparse tensor representing an adjacency
-            matrix.
+        src (:class:`SparseTensor`): The sparse tensor.
         other (:class:`Tensor` or :class:`SparseTensor`): The second matrix.
         reduce (string, optional): The function to reduce along the rows of
             'src' and columns of 'other'. Can be 'sum', 'add', 'mean', 'min',

--- a/torch_sparse/matmul.py
+++ b/torch_sparse/matmul.py
@@ -149,7 +149,7 @@ def matmul(src, other, reduce="sum"):  # noqa: F811
     Args:
         src (:class:`Tensor`): A sparse tensor representing an adjacency
             matrix.
-        other (:class:`Tensor`): Can be either a sparse or a dense tensor.
+        other (:class:`Tensor` or :class:`SparseTensor`): The second matrix.
         reduce (string, optional): The function to reduce along the rows of
             'src' and columns of 'other'. Can be 'sum', 'add', 'mean', 'min',
             or 'max'.

--- a/torch_sparse/matmul.py
+++ b/torch_sparse/matmul.py
@@ -150,8 +150,9 @@ def matmul(src, other, reduce="sum"):  # noqa: F811
         src (:class:`SparseTensor`): The sparse tensor.
         other (:class:`Tensor` or :class:`SparseTensor`): The second matrix.
         reduce (string, optional): The function to reduce along the rows of
-            'src' and columns of 'other'. Can be 'sum', 'add', 'mean', 'min',
-            or 'max'.
+            :obj:`src` and columns of :obj:`other`. Can be :obj:`"sum"`,
+            :obj:`"mean"`, :obj:`"min"` or :obj:`"max"`.
+            (default: :obj:`"sum"`)
 
     :rtype: (:class:`Tensor`)
     """

--- a/torch_sparse/matmul.py
+++ b/torch_sparse/matmul.py
@@ -144,8 +144,7 @@ def matmul(src, other, reduce="sum"):  # noqa: F811
      stored as a list of edges. This method multiplies elements along the rows
      of the adjacency matrix with the column of the other matrix. In regular
      matrix multiplication, the products are then summed together, but this
-     method allows us to use other aggregation functions.
-
+     method allows us to use other aggregation functions as well.
 
     Args:
         src (:class:`Tensor`): A sparse tensor representing an adjacency

--- a/torch_sparse/matmul.py
+++ b/torch_sparse/matmul.py
@@ -139,6 +139,22 @@ def matmul(src, other, reduce):  # noqa: F811
 
 
 def matmul(src, other, reduce="sum"):  # noqa: F811
+    """Matrix product of a sparse tensor with either another sparse tensor or a
+     dense tensor. The sparse tensor represents an adjacency matrix and is
+     stored as a list of edges. This method multiples elements along the rows
+     of the adjacency matrix with the column of the other matrix. In regular
+     matrix multiplication, the products are then summed together, but this
+     method allows us to use other aggregation functions.
+
+
+    Args:
+        src (:class:`Tensor`): A sparse tensor representing an adjacency matrix.
+        other (:class:`Tensor`): Can be either a sparse or a dense tensor.
+        reduce (string, optional): The function to reduce along the rows of 'src' and columns of
+            'other'. Can be 'sum', 'add', 'mean', 'min', or 'max'.
+
+    :rtype: (:class:`Tensor`)
+    """
     if isinstance(other, torch.Tensor):
         return spmm(src, other, reduce)
     elif isinstance(other, SparseTensor):

--- a/torch_sparse/matmul.py
+++ b/torch_sparse/matmul.py
@@ -148,10 +148,12 @@ def matmul(src, other, reduce="sum"):  # noqa: F811
 
 
     Args:
-        src (:class:`Tensor`): A sparse tensor representing an adjacency matrix.
+        src (:class:`Tensor`): A sparse tensor representing an adjacency
+            matrix.
         other (:class:`Tensor`): Can be either a sparse or a dense tensor.
-        reduce (string, optional): The function to reduce along the rows of 'src' and columns of
-            'other'. Can be 'sum', 'add', 'mean', 'min', or 'max'.
+        reduce (string, optional): The function to reduce along the rows of
+            'src' and columns of 'other'. Can be 'sum', 'add', 'mean', 'min',
+            or 'max'.
 
     :rtype: (:class:`Tensor`)
     """

--- a/torch_sparse/matmul.py
+++ b/torch_sparse/matmul.py
@@ -141,7 +141,7 @@ def matmul(src, other, reduce):  # noqa: F811
 def matmul(src, other, reduce="sum"):  # noqa: F811
     """Matrix product of a sparse tensor with either another sparse tensor or a
      dense tensor. The sparse tensor represents an adjacency matrix and is
-     stored as a list of edges. This method multiples elements along the rows
+     stored as a list of edges. This method multiplies elements along the rows
      of the adjacency matrix with the column of the other matrix. In regular
      matrix multiplication, the products are then summed together, but this
      method allows us to use other aggregation functions.


### PR DESCRIPTION
I found that torch_sparse.matmul was missing docs and it took me a while to understand what the reduce parameter did. So I decided to add some comments.

Hope this gets accepted. :)