### PR TITLE
Adding support in torch_sparse.narrow for  bidimensional option that return square adj matrix

### DIFF
--- a/torch_sparse/narrow.py
+++ b/torch_sparse/narrow.py
@@ -1,11 +1,55 @@
 from typing import Tuple
 
+import torch
 from torch_sparse.storage import SparseStorage
 from torch_sparse.tensor import SparseTensor
 
 
 def narrow(src: SparseTensor, dim: int, start: int,
-           length: int) -> SparseTensor:
+           length: int, bidim: False, n_active_nodes: None) -> SparseTensor:
+    r"""It resizes :obj:`src` SparseTensor along one specified dimension, or two dimensions at the same time
+    if the SparseTensor has 2 dimensions. In the latter case, it returns a squared SparseTensor.
+    In the case of 1-dimensional resizing, :obj:'start' and :obj:'lenght' are supported
+    In the case of bidimensional resizing, resizing always starts from 0, and it returns a square matrix;
+    :obj:`src` must be a bidimensional SparseTensor for bidim option to work.
+    Args:
+        src (SparseTensor): SparseTensor to be manipulated
+        dim (int): dimension along which the resizing is done. Not used in case bidim is True
+        start (int): first position to include in the ouput. Not used in case bidim is True (set to 0)
+        length (int): last position to include in the output.
+        bidim (bool):  it applies bidimensional and squared narrowing of the src, which must be a bidimensional SparseTensor.
+        n_active_nodes (int): Required only if bidim option is True; used for efficient manipulation of the rowptr in bidim case.
+    """
+    if bidim: 
+        if len(src.storage._sparse_sizes) != 2:
+            raise NotImplemented # bidim case works only for bidimensional tensors
+        
+        start = 0 # only start at 0 is supported for bidim resizing
+        if src.storage._rowptr is None:
+            rowptr, col, value = src.csr()
+
+        # rowptr
+        rowptr = torch.narrow(src.storage._rowptr, 0, start, length + 1).clone()
+        rowptr[(n_active_nodes + 1):] = rowptr[n_active_nodes]
+
+        # col and value
+        col = torch.narrow(src.storage._col, 0, start, rowptr[-1])
+        value = torch.narrow(src.storage._value, 0, start, rowptr[-1]
+                                ) if src.storage._value is not None else None
+
+        # indeces for conversion to csc
+        csr2csc = src.storage._csr2csc[src.storage._csr2csc < len(col)] \
+            if src.storage._csr2csc is not None else None
+        
+        # update storage and edge_index
+        storage = SparseStorage(row=None, rowptr=rowptr, col=col,
+                                value=value, sparse_sizes=(length, length),
+                                rowcount=None, colptr=None,
+                                colcount=None, csr2csc=csr2csc,
+                                csc2csr=None, is_sorted=True,
+                                trust_data=False)
+        return src.from_storage(storage)
+      
     if dim < 0:
         dim = src.dim() + dim
 
@@ -130,7 +174,7 @@ def __narrow_diag__(src: SparseTensor, start: Tuple[int, int],
     return src.from_storage(storage)
 
 
-SparseTensor.narrow = lambda self, dim, start, length: narrow(
-    self, dim, start, length)
+SparseTensor.narrow = lambda self, dim, start, length, bidim, n_active_nodes : narrow(
+    self, dim, start, length, bidim, n_active_nodes)
 SparseTensor.__narrow_diag__ = lambda self, start, length: __narrow_diag__(
     self, start, length)

--- a/torch_sparse/narrow.py
+++ b/torch_sparse/narrow.py
@@ -6,36 +6,49 @@ from torch_sparse.tensor import SparseTensor
 
 
 def narrow(src: SparseTensor, dim: int, start: int,
-           length: int, bidim: False, n_active_nodes: None) -> SparseTensor:
-    r"""It resizes :obj:`src` SparseTensor along one specified dimension, or two dimensions at the same time
-    if the SparseTensor has 2 dimensions. In the latter case, it returns a squared SparseTensor.
-    In the case of 1-dimensional resizing, :obj:'start' and :obj:'lenght' are supported
-    In the case of bidimensional resizing, resizing always starts from 0, and it returns a square matrix;
-    :obj:`src` must be a bidimensional SparseTensor for bidim option to work.
+           length: int, bidim: False, 
+           n_active_nodes: None) -> SparseTensor:
+    r"""It resizes :obj:`src` SparseTensor along one 
+    specified dimension, or two dimensions at the same time
+    if the SparseTensor has 2 dimensions. In the 
+    latter case, it returns a squared SparseTensor.
+    In the case of 1-dimensional resizing,
+    :obj:'start' and :obj:'lenght' are supported
+    In the case of bidimensional resizing, resizing
+    always starts from 0, and it returns a square matrix;
+    :obj:`src` must be a bidimensional SparseTensor
+    for bidim option to work.
     Args:
         src (SparseTensor): SparseTensor to be manipulated
-        dim (int): dimension along which the resizing is done. Not used in case bidim is True
-        start (int): first position to include in the ouput. Not used in case bidim is True (set to 0)
+        dim (int): dimension along which the resizing is done.
+                    Not used in case bidim is True
+        start (int): first position to include in the ouput.
+                    Not used in case bidim is True (set to 0)
         length (int): last position to include in the output.
-        bidim (bool):  it applies bidimensional and squared narrowing of the src, which must be a bidimensional SparseTensor.
-        n_active_nodes (int): Required only if bidim option is True; used for efficient manipulation of the rowptr in bidim case.
+        bidim (bool):  it applies bidimensional and squared narrowing
+                    of the src, which must be a bidimensional SparseTensor.
+        n_active_nodes (int): Required only if bidim option is True;
+                    used for efficient manipulation of the rowptr in bidim case.
     """
     if bidim: 
         if len(src.storage._sparse_sizes) != 2:
-            raise NotImplemented # bidim case works only for bidimensional tensors
+            raise NotImplementedError 
         
         start = 0 # only start at 0 is supported for bidim resizing
         if src.storage._rowptr is None:
             rowptr, col, value = src.csr()
 
         # rowptr
-        rowptr = torch.narrow(src.storage._rowptr, 0, start, length + 1).clone()
+        rowptr = torch.narrow(src.storage._rowptr, 
+                              0, start, length + 1).clone()
         rowptr[(n_active_nodes + 1):] = rowptr[n_active_nodes]
 
         # col and value
-        col = torch.narrow(src.storage._col, 0, start, rowptr[-1])
-        value = torch.narrow(src.storage._value, 0, start, rowptr[-1]
-                                ) if src.storage._value is not None else None
+        col = torch.narrow(src.storage._col, 
+                           0, start, rowptr[-1])
+        value = torch.narrow(src.storage._value,
+                    0, start, rowptr[-1]
+                        ) if src.storage._value is not None else None
 
         # indeces for conversion to csc
         csr2csc = src.storage._csr2csc[src.storage._csr2csc < len(col)] \
@@ -174,7 +187,9 @@ def __narrow_diag__(src: SparseTensor, start: Tuple[int, int],
     return src.from_storage(storage)
 
 
-SparseTensor.narrow = lambda self, dim, start, length, bidim, n_active_nodes : narrow(
-    self, dim, start, length, bidim, n_active_nodes)
+SparseTensor.narrow = lambda self, dim, start, length, \
+                        bidim=False, n_active_nodes=None: narrow(
+                        self, dim, start, length, 
+                        bidim, n_active_nodes)
 SparseTensor.__narrow_diag__ = lambda self, start, length: __narrow_diag__(
     self, start, length)

--- a/torch_sparse/narrow.py
+++ b/torch_sparse/narrow.py
@@ -6,11 +6,11 @@ from torch_sparse.tensor import SparseTensor
 
 
 def narrow(src: SparseTensor, dim: int, start: int,
-           length: int, bidim: False, 
+           length: int, bidim: False,
            n_active_nodes: None) -> SparseTensor:
-    r"""It resizes :obj:`src` SparseTensor along one 
+    r"""It resizes :obj:`src` SparseTensor along one
     specified dimension, or two dimensions at the same time
-    if the SparseTensor has 2 dimensions. In the 
+    if the SparseTensor has 2 dimensions. In the
     latter case, it returns a squared SparseTensor.
     In the case of 1-dimensional resizing,
     :obj:'start' and :obj:'lenght' are supported
@@ -28,32 +28,32 @@ def narrow(src: SparseTensor, dim: int, start: int,
         bidim (bool):  it applies bidimensional and squared narrowing
                     of the src, which must be a bidimensional SparseTensor.
         n_active_nodes (int): Required only if bidim option is True;
-                    used for efficient manipulation of the rowptr in bidim case.
+                    for efficient manipulation of the rowptr bidim case.
     """
-    if bidim: 
+    if bidim:
         if len(src.storage._sparse_sizes) != 2:
-            raise NotImplementedError 
-        
-        start = 0 # only start at 0 is supported for bidim resizing
+            raise NotImplementedError
+               
+        start = 0
         if src.storage._rowptr is None:
             rowptr, col, value = src.csr()
 
         # rowptr
-        rowptr = torch.narrow(src.storage._rowptr, 
+        rowptr = torch.narrow(src.storage._rowptr,
                               0, start, length + 1).clone()
         rowptr[(n_active_nodes + 1):] = rowptr[n_active_nodes]
 
         # col and value
-        col = torch.narrow(src.storage._col, 
+        col = torch.narrow(src.storage._col,
                            0, start, rowptr[-1])
         value = torch.narrow(src.storage._value,
                     0, start, rowptr[-1]
-                        ) if src.storage._value is not None else None
+                    ) if src.storage._value is not None else None
 
         # indeces for conversion to csc
         csr2csc = src.storage._csr2csc[src.storage._csr2csc < len(col)] \
             if src.storage._csr2csc is not None else None
-        
+                
         # update storage and edge_index
         storage = SparseStorage(row=None, rowptr=rowptr, col=col,
                                 value=value, sparse_sizes=(length, length),
@@ -62,7 +62,7 @@ def narrow(src: SparseTensor, dim: int, start: int,
                                 csc2csr=None, is_sorted=True,
                                 trust_data=False)
         return src.from_storage(storage)
-      
+    
     if dim < 0:
         dim = src.dim() + dim
 
@@ -188,8 +188,7 @@ def __narrow_diag__(src: SparseTensor, start: Tuple[int, int],
 
 
 SparseTensor.narrow = lambda self, dim, start, length, \
-                        bidim=False, n_active_nodes=None: narrow(
-                        self, dim, start, length, 
-                        bidim, n_active_nodes)
+    bidim=False, n_active_nodes=None: narrow(self, dim, start, length, 
+        bidim, n_active_nodes)
 SparseTensor.__narrow_diag__ = lambda self, start, length: __narrow_diag__(
     self, start, length)

--- a/torch_sparse/narrow.py
+++ b/torch_sparse/narrow.py
@@ -33,7 +33,7 @@ def narrow(src: SparseTensor, dim: int, start: int,
     if bidim:
         if len(src.storage._sparse_sizes) != 2:
             raise NotImplementedError
-               
+        
         start = 0
         if src.storage._rowptr is None:
             rowptr, col, value = src.csr()
@@ -47,13 +47,14 @@ def narrow(src: SparseTensor, dim: int, start: int,
         col = torch.narrow(src.storage._col,
                            0, start, rowptr[-1])
         value = torch.narrow(src.storage._value,
-                    0, start, rowptr[-1]
-                    ) if src.storage._value is not None else None
+                             0, start, rowptr[-1]) \
+                                if src.storage._value \
+                                    is not None else None
 
         # indeces for conversion to csc
         csr2csc = src.storage._csr2csc[src.storage._csr2csc < len(col)] \
             if src.storage._csr2csc is not None else None
-                
+        
         # update storage and edge_index
         storage = SparseStorage(row=None, rowptr=rowptr, col=col,
                                 value=value, sparse_sizes=(length, length),
@@ -188,7 +189,7 @@ def __narrow_diag__(src: SparseTensor, start: Tuple[int, int],
 
 
 SparseTensor.narrow = lambda self, dim, start, length, \
-    bidim=False, n_active_nodes=None: narrow(self, dim, start, length, 
-        bidim, n_active_nodes)
+    bidim=False, n_active_nodes=None: narrow(self, dim, start, length,
+                                                  bidim, n_active_nodes)
 SparseTensor.__narrow_diag__ = lambda self, start, length: __narrow_diag__(
     self, start, length)


### PR DESCRIPTION
A way to support the necessary trimming of the adjacency matrix for the trim_to_layer  function, already [present in pytorch_geometric](https://github.com/pyg-team/pytorch_geometric/pull/6661/files#diff-7c2ebdedf830bb42c143588c9f09a42bbadb4b08e571c3e07a7c057a58bbdf8d), for the case of (CSR) SparseTensor is provided.
Currently trim_to_layer supports COO case for Homogeneous Graphs. 
SparseTensor support is still missing there, and it will be added once the SparseTensor class has the possibility to trim the adjacency matrix accordingly.