### PR TITLE
[ROCm] fixes ambiguous calls to `shfl*` where there is no explicit type conversion from `c10::Half` to `__half`

### DIFF
--- a/csrc/cuda/utils.cuh
+++ b/csrc/cuda/utils.cuh
@@ -6,15 +6,37 @@
   AT_ASSERTM(x.device().is_cuda(), #x " must be CUDA tensor")
 #define CHECK_INPUT(x) AT_ASSERTM(x, "Input mismatch")
 
-__device__ __inline__ at::Half
-__shfl_sync(const unsigned mask, const at::Half var, const int srcLane) {
-  return __shfl_sync(mask, var.operator __half(), srcLane);
+__device__ __inline__ at::Half __shfl_up_sync(const unsigned mask,
+                                              const at::Half var,
+                                              const unsigned int delta) {
+  return __shfl_up_sync(mask, var.operator __half(), delta);
 }
 
 __device__ __inline__ at::Half __shfl_down_sync(const unsigned mask,
                                                 const at::Half var,
                                                 const unsigned int delta) {
   return __shfl_down_sync(mask, var.operator __half(), delta);
+}
+
+__device__ __inline__ at::Half __shfl_sync(const unsigned mask,
+                                           const at::Half var,
+                                           const int delta) {
+  return __shfl_sync(mask, var.operator __half(), delta);
+}
+
+__device__ __inline__ at::Half __shfl_up(const at::Half var,
+                                         const unsigned int delta) {
+  return __shfl_up(var.operator __half(), delta);
+}
+
+__device__ __inline__ at::Half __shfl_down(const at::Half var,
+                                           const unsigned int delta) {
+  return __shfl_down(var.operator __half(), delta);
+}
+
+__device__ __inline__ at::Half
+__shfl(const at::Half var, const int delta) {
+  return __shfl(var.operator __half(), delta);
 }
 
 #ifdef USE_ROCM


### PR DESCRIPTION
Also resolves https://github.com/ROCm/ROCm/issues/2783

I can create a similar PR for pytorch_scatter.