### PR TITLE
Moved CMAKE_CXX_STANDARD from 14 to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(torchsparse)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(TORCHSPARSE_VERSION 0.6.18)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
This moves the CMAKE_CXX_STANDARD from 14 to 17. Without is the libtorchsparse is triggering libtorch CXX 17 required error.