### PR TITLE
Use 64-bit warp mask for ROCm HIP compatibility

### DIFF
--- a/csrc/cuda/utils.cuh
+++ b/csrc/cuda/utils.cuh
@@ -6,19 +6,25 @@
   AT_ASSERTM(x.device().is_cuda(), #x " must be CUDA tensor")
 #define CHECK_INPUT(x) AT_ASSERTM(x, "Input mismatch")
 
-__device__ __inline__ at::Half __shfl_up_sync(const unsigned mask,
+#ifdef USE_ROCM
+  using warp_mask_t = unsigned long long;
+#else
+  using warp_mask_t = unsigned int;
+#endif
+
+__device__ __inline__ at::Half __shfl_up_sync(const warp_mask_t mask,
                                               const at::Half var,
                                               const unsigned int delta) {
   return __shfl_up_sync(mask, var.operator __half(), delta);
 }
 
-__device__ __inline__ at::Half __shfl_down_sync(const unsigned mask,
+__device__ __inline__ at::Half __shfl_down_sync(const warp_mask_t mask,
                                                 const at::Half var,
                                                 const unsigned int delta) {
   return __shfl_down_sync(mask, var.operator __half(), delta);
 }
 
-__device__ __inline__ at::Half __shfl_sync(const unsigned mask,
+__device__ __inline__ at::Half __shfl_sync(const warp_mask_t mask,
                                            const at::Half var,
                                            const int delta) {
   return __shfl_sync(mask, var.operator __half(), delta);


### PR DESCRIPTION
Same change that when into torch-scatter here https://github.com/rusty1s/pytorch_scatter/commit/648dda3cf964731ffb4de11eafc445a83133eda4 from @Looong01.

ROCm 6.4.3+ __shfl_sync / __shfl_up_sync / __shfl_down_sync function templates now require the mask parameter to be a 64-bit integer (uint64_t). 

Before this patch, we'd see `static assertion failed: sizeof(unsigned int) == 8` when building for ROCm.

With this patch, build is successful.